### PR TITLE
Fix timeout initialization in OpenAI client

### DIFF
--- a/core/generate_daily_news.py
+++ b/core/generate_daily_news.py
@@ -7,7 +7,7 @@ from common.config import Config
 from core.get_ai_result import get_ai_result
 
 config = Config()
-llm_client = OpenAI(base_url=config.llm_base_url, api_key=config.llm_api_key)
+llm_client = OpenAI(base_url=config.llm_base_url, api_key=config.llm_api_key, timeout=config.llm_timeout)
 
 def generate_daily_news(miniflux_client):
     logger.info('Generating daily news')

--- a/core/get_ai_result.py
+++ b/core/get_ai_result.py
@@ -2,7 +2,7 @@ from openai import OpenAI
 from common.config import Config
 
 config = Config()
-llm_client = OpenAI(base_url=config.llm_base_url, api_key=config.llm_api_key)
+llm_client = OpenAI(base_url=config.llm_base_url, api_key=config.llm_api_key, timeout=config.llm_timeout)
 
 def get_ai_result(prompt, request):
     messages = [

--- a/core/process_entries.py
+++ b/core/process_entries.py
@@ -10,7 +10,7 @@ from common.logger import logger
 from core.entry_filter import filter_entry
 
 config = Config()
-llm_client = OpenAI(base_url=config.llm_base_url, api_key=config.llm_api_key)
+llm_client = OpenAI(base_url=config.llm_base_url, api_key=config.llm_api_key, timeout=config.llm_timeout)
 file_lock = threading.Lock()
 
 @sleep_and_retry

--- a/myapp/ai_news.py
+++ b/myapp/ai_news.py
@@ -11,7 +11,7 @@ from common.config import Config
 from myapp import app
 
 config = Config()
-llm_client = OpenAI(base_url=config.llm_base_url, api_key=config.llm_api_key)
+llm_client = OpenAI(base_url=config.llm_base_url, api_key=config.llm_api_key, timeout=config.llm_timeout)
 
 @app.route('/rss/ai-news', methods=['GET'])
 def miniflux_ai_news():


### PR DESCRIPTION
The OpenAI client was not being initialized with the timeout configuration from config.yml, causing it to use httpx's default 5-second timeout for connection establishment. This led to timeout errors when connecting to remote LLM servers.

This commit adds the timeout parameter to all OpenAI client initializations in the following files:
- core/process_entries.py
- core/generate_daily_news.py
- core/get_ai_result.py
- myapp/ai_news.py

The timeout value is now properly passed from config.llm_timeout to ensure all HTTP operations respect the configured timeout setting.