### PR TITLE
Support LLM extra request params

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -2,7 +2,8 @@ from yaml import safe_load
 
 class Config:
     def __init__(self):
-        self.c = safe_load(open('config.yml', encoding='utf8'))
+        with open('config.yml', encoding='utf8') as config_file:
+            self.c = safe_load(config_file)
         self.log_level = self.c.get('log_level', 'INFO')
 
         self.miniflux_base_url = self.get_config_value('miniflux', 'base_url', None)
@@ -18,6 +19,11 @@ class Config:
         self.llm_timeout = self.get_config_value('llm', 'timeout', 60)
         self.llm_max_workers = self.get_config_value('llm', 'max_workers', 4)
         self.llm_RPM = self.get_config_value('llm', 'RPM', 1000)
+        self.llm_extra_params = self.get_config_value('llm', 'extra_params', {})
+        if self.llm_extra_params is None:
+            self.llm_extra_params = {}
+        if not isinstance(self.llm_extra_params, dict):
+            raise ValueError('llm.extra_params must be a mapping')
 
         self.ai_news_url = self.get_config_value('ai_news', 'url', None)
         self.ai_news_schedule = self.get_config_value('ai_news', 'schedule', None)

--- a/config.sample.Chinese.yml
+++ b/config.sample.Chinese.yml
@@ -26,6 +26,16 @@ llm:
   # max_workers: 4
   # Request per minute(RPM) limit, default 1000
   # RPM: 15
+  # 额外请求参数，会透传到当前 LLM provider 的请求方法
+  # 可用于关闭 reasoning/thinking，或传递未来新增的参数，例如：
+  # extra_params:
+  #   thinking_config:
+  #     thinking_budget: 0
+  # OpenAI 兼容接口也可使用 extra_body：
+  # extra_params:
+  #   extra_body:
+  #     chat_template_kwargs:
+  #       enable_thinking: false
 
 ai_news:
   # for docker compose environment, use docker container_name

--- a/config.sample.English.yml
+++ b/config.sample.English.yml
@@ -26,6 +26,16 @@ llm:
   # max_workers: 4
   # Request per minute(RPM) limit, default 1000
   # RPM: 15
+  # Extra request parameters passed through to the current LLM provider request.
+  # This can be used to disable reasoning/thinking or set future parameters, for example:
+  # extra_params:
+  #   thinking_config:
+  #     thinking_budget: 0
+  # OpenAI-compatible APIs can also use extra_body:
+  # extra_params:
+  #   extra_body:
+  #     chat_template_kwargs:
+  #       enable_thinking: false
 
 ai_news:
   # for docker compose environment, use docker container_name

--- a/core/get_ai_result.py
+++ b/core/get_ai_result.py
@@ -35,6 +35,7 @@ def get_ai_result(prompt: str, request: str):
                 contents=contents,
                 config=types.GenerateContentConfig(
                     system_instruction=instruction,
+                    **config.llm_extra_params,
                 ),
             )
             return response.text
@@ -62,7 +63,10 @@ def get_ai_result(prompt: str, request: str):
 
         try:
             completion = llm_client.chat.completions.create(
-                model=config.llm_model, messages=messages, timeout=config.llm_timeout
+                model=config.llm_model,
+                messages=messages,
+                timeout=config.llm_timeout,
+                **config.llm_extra_params,
             )
 
             response_content = completion.choices[0].message.content

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,60 @@
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def load_config_class():
+    config_path = Path(__file__).resolve().parents[1] / "common" / "config.py"
+    spec = importlib.util.spec_from_file_location("config_mod", config_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.Config
+
+
+class ConfigTestCase(unittest.TestCase):
+    def setUp(self):
+        self.Config = load_config_class()
+        self.old_cwd = os.getcwd()
+        self.tmpdir = tempfile.TemporaryDirectory()
+        os.chdir(self.tmpdir.name)
+
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+        self.tmpdir.cleanup()
+
+    def write_config(self, content):
+        Path("config.yml").write_text(content, encoding="utf8")
+
+    def test_extra_params_defaults_to_empty_mapping(self):
+        self.write_config("llm:\n  extra_params:\n")
+
+        config = self.Config()
+
+        self.assertEqual(config.llm_extra_params, {})
+
+    def test_extra_params_accepts_nested_mapping(self):
+        self.write_config(
+            "llm:\n"
+            "  extra_params:\n"
+            "    thinking_config:\n"
+            "      thinking_budget: 0\n"
+        )
+
+        config = self.Config()
+
+        self.assertEqual(
+            config.llm_extra_params,
+            {"thinking_config": {"thinking_budget": 0}},
+        )
+
+    def test_extra_params_rejects_non_mapping(self):
+        self.write_config("llm:\n  extra_params: nope\n")
+
+        with self.assertRaises(ValueError):
+            self.Config()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add llm.extra_params config support and validate it as a mapping
- pass extra params through to OpenAI-compatible chat completions and Gemini generate content configs
- document thinking/reasoning disable examples in both sample configs
- add unit tests for extra_params parsing

## Tests
- python -m unittest tests.test_config

Note: full python -m unittest still fails in this checkout because discovery imports runtime packages without config.yml and the environment is missing flask; this predates this change.