### PR TITLE
fix miniflux 2.3.0 limit to 1000 entries

### DIFF
--- a/core/fetch_unread_entries.py
+++ b/core/fetch_unread_entries.py
@@ -7,7 +7,7 @@ from core.process_entries import process_entry
 
 
 def fetch_unread_entries(config, miniflux_client):
-    entries = miniflux_client.get_entries(status=['unread'], limit=10000)
+    entries = miniflux_client.get_entries(status=['unread'], limit=1000)
     start_time = time.time()
     logger.info('Get unread entries: ' + str(len(entries['entries']))) if len(entries['entries']) > 0 else logger.info('No new entries')
 


### PR DESCRIPTION
Crash loop of miniflux-ai since [Miniflux 2.3.0](https://github.com/miniflux/v2/releases/tag/2.3.0) because of this:
> Cap the maximum entry limit to 1000 across the UI, API, and storage layer.
