### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/config.sample.English.yml
+++ b/config.sample.English.yml
@@ -10,12 +10,17 @@ miniflux:
   # webhook_secret: Miniflux_webhook_secret_here
 
 llm:
-  # provider: gemini # openai (default) or gemini
+  # provider: gemini # openai (default), gemini, or litellm
 
   # Gemini Example
   # base_url: https://generativelanguage.googleapis.com
   # api_key: your_gemini_api_key
   # model: gemini-2.5-flash
+
+  # LiteLLM Example (100+ providers: https://docs.litellm.ai/docs/providers)
+  # provider: litellm
+  # model: anthropic/claude-sonnet-4-6  # or openai/gpt-4o, groq/llama-3.3-70b-versatile, etc.
+  # api_key: your_api_key  # optional — LiteLLM reads from provider env vars (ANTHROPIC_API_KEY, etc.)
 
   base_url: http://host.docker.internal:11434/v1
   api_key: ollama

--- a/core/get_ai_result.py
+++ b/core/get_ai_result.py
@@ -15,6 +15,20 @@ elif config.llm_provider == "gemini":
         http_options=types.HttpOptions(base_url=config.llm_base_url),
         api_key=config.llm_api_key,
     )
+elif config.llm_provider == "litellm":
+    llm_client = None
+
+
+def _build_messages(prompt: str, request: str):
+    if "${content}" in prompt:
+        return [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": prompt.replace("${content}", md(request))},
+        ]
+    return [
+        {"role": "system", "content": prompt},
+        {"role": "user", "content": "The following is the input content:\n---\n " + md(request)},
+    ]
 
 
 def get_ai_result(prompt: str, request: str):
@@ -42,24 +56,30 @@ def get_ai_result(prompt: str, request: str):
         except Exception as e:
             logger.error(f"Error in get_ai_result (Gemini): {e}")
             raise
+    elif config.llm_provider == "litellm":
+        import litellm
+
+        messages = _build_messages(prompt, request)
+        kwargs = {
+            "model": config.llm_model,
+            "messages": messages,
+            "timeout": config.llm_timeout,
+            "drop_params": True,
+            **config.llm_extra_params,
+        }
+        if config.llm_api_key:
+            kwargs["api_key"] = config.llm_api_key
+        if config.llm_base_url:
+            kwargs["api_base"] = config.llm_base_url
+
+        try:
+            completion = litellm.completion(**kwargs)
+            return completion.choices[0].message.content
+        except Exception as e:
+            logger.error(f"Error in get_ai_result (LiteLLM): {e}")
+            raise
     else:
-        if "${content}" in prompt:
-            messages = [
-                {"role": "system", "content": "You are a helpful assistant."},
-                {
-                    "role": "user",
-                    "content": prompt.replace("${content}", md(request)),
-                },
-            ]
-        else:
-            messages = [
-                {"role": "system", "content": prompt},
-                {
-                    "role": "user",
-                    "content": "The following is the input content:\n---\n "
-                    + md(request),
-                },
-            ]
+        messages = _build_messages(prompt, request)
 
         try:
             completion = llm_client.chat.completions.create(

--- a/core/get_ai_result.py
+++ b/core/get_ai_result.py
@@ -1,5 +1,13 @@
 from markdownify import markdownify as md
 
+import litellm
+from litellm.exceptions import (
+    AuthenticationError,
+    BadRequestError,
+    NotFoundError,
+    RateLimitError,
+    Timeout,
+)
 from openai import OpenAI
 from google import genai
 from google.genai import types
@@ -57,15 +65,6 @@ def get_ai_result(prompt: str, request: str):
             logger.error(f"Error in get_ai_result (Gemini): {e}")
             raise
     elif config.llm_provider == "litellm":
-        import litellm
-        from litellm.exceptions import (
-            AuthenticationError,
-            BadRequestError,
-            NotFoundError,
-            RateLimitError,
-            Timeout,
-        )
-
         messages = _build_messages(prompt, request)
         kwargs = {
             "model": config.llm_model,

--- a/core/get_ai_result.py
+++ b/core/get_ai_result.py
@@ -58,6 +58,13 @@ def get_ai_result(prompt: str, request: str):
             raise
     elif config.llm_provider == "litellm":
         import litellm
+        from litellm.exceptions import (
+            AuthenticationError,
+            BadRequestError,
+            NotFoundError,
+            RateLimitError,
+            Timeout,
+        )
 
         messages = _build_messages(prompt, request)
         kwargs = {
@@ -74,7 +81,26 @@ def get_ai_result(prompt: str, request: str):
 
         try:
             completion = litellm.completion(**kwargs)
-            return completion.choices[0].message.content
+            content = completion.choices[0].message.content
+            if content is None:
+                logger.warning("LiteLLM returned empty response content")
+                return ""
+            return content
+        except AuthenticationError as e:
+            logger.error(f"LiteLLM authentication failed (check API key): {e}")
+            raise
+        except NotFoundError as e:
+            logger.error(f"LiteLLM model not found (check model string format, e.g. 'openai/gpt-4o'): {e}")
+            raise
+        except RateLimitError as e:
+            logger.error(f"LiteLLM rate limit exceeded: {e}")
+            raise
+        except Timeout as e:
+            logger.error(f"LiteLLM request timed out: {e}")
+            raise
+        except BadRequestError as e:
+            logger.error(f"LiteLLM bad request (check model/params): {e}")
+            raise
         except Exception as e:
             logger.error(f"Error in get_ai_result (LiteLLM): {e}")
             raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ feedgen
 schedule
 ratelimit
 google-genai
+litellm>=1.80.0,<1.87

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,113 @@
+import os
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+# Stub litellm before importing
+_fake_litellm = types.ModuleType("litellm")
+
+_fake_message = mock.MagicMock()
+_fake_message.content = "Test summary"
+
+_fake_choice = mock.MagicMock()
+_fake_choice.message = _fake_message
+
+_fake_response = mock.MagicMock()
+_fake_response.choices = [_fake_choice]
+
+_fake_litellm.completion = mock.MagicMock(return_value=_fake_response)
+sys.modules["litellm"] = _fake_litellm
+
+
+@pytest.fixture(autouse=True)
+def reset_mocks():
+    _fake_litellm.completion.reset_mock()
+    _fake_litellm.completion.return_value = _fake_response
+    _fake_message.content = "Test summary"
+    yield
+
+
+@pytest.fixture(autouse=True)
+def setup_config(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(
+        """
+llm:
+  provider: litellm
+  model: anthropic/claude-sonnet-4-6
+  api_key: sk-test-123
+  timeout: 30
+miniflux:
+  base_url: http://localhost
+  api_key: test
+"""
+    )
+    monkeypatch.chdir(tmp_path)
+    # Clear cached modules so Config re-reads config.yml from new cwd
+    for mod_name in list(sys.modules):
+        if mod_name.startswith("core.") or mod_name.startswith("common."):
+            del sys.modules[mod_name]
+    yield
+
+
+def test_litellm_basic_call():
+    from core.get_ai_result import get_ai_result
+
+    result = get_ai_result("Summarize this", "<p>Hello world</p>")
+    assert result == "Test summary"
+    _fake_litellm.completion.assert_called_once()
+
+
+def test_litellm_drop_params():
+    from core.get_ai_result import get_ai_result
+
+    get_ai_result("Summarize", "<p>Test</p>")
+    call_kwargs = _fake_litellm.completion.call_args[1]
+    assert call_kwargs["drop_params"] is True
+
+
+def test_litellm_model_forwarded():
+    from core.get_ai_result import get_ai_result
+
+    get_ai_result("Summarize", "<p>Test</p>")
+    call_kwargs = _fake_litellm.completion.call_args[1]
+    assert call_kwargs["model"] == "anthropic/claude-sonnet-4-6"
+
+
+def test_litellm_api_key_forwarded():
+    from core.get_ai_result import get_ai_result
+
+    get_ai_result("Summarize", "<p>Test</p>")
+    call_kwargs = _fake_litellm.completion.call_args[1]
+    assert call_kwargs["api_key"] == "sk-test-123"
+
+
+def test_litellm_content_placeholder():
+    from core.get_ai_result import get_ai_result
+
+    get_ai_result("Process ${content} now", "<p>Hello</p>")
+    call_kwargs = _fake_litellm.completion.call_args[1]
+    messages = call_kwargs["messages"]
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == "You are a helpful assistant."
+    assert "Hello" in messages[1]["content"]
+
+
+def test_litellm_system_prompt():
+    from core.get_ai_result import get_ai_result
+
+    get_ai_result("Custom system prompt", "<p>Content</p>")
+    call_kwargs = _fake_litellm.completion.call_args[1]
+    messages = call_kwargs["messages"]
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == "Custom system prompt"
+
+
+def test_litellm_timeout_forwarded():
+    from core.get_ai_result import get_ai_result
+
+    get_ai_result("Summarize", "<p>Test</p>")
+    call_kwargs = _fake_litellm.completion.call_args[1]
+    assert call_kwargs["timeout"] == 30

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -5,8 +5,40 @@ from unittest import mock
 
 import pytest
 
-# Stub litellm before importing
+# ---------------------------------------------------------------------------
+# Stub litellm + its exceptions before any project imports
+# ---------------------------------------------------------------------------
 _fake_litellm = types.ModuleType("litellm")
+_fake_exceptions = types.ModuleType("litellm.exceptions")
+
+
+class _FakeAuthenticationError(Exception):
+    pass
+
+
+class _FakeBadRequestError(Exception):
+    pass
+
+
+class _FakeNotFoundError(Exception):
+    pass
+
+
+class _FakeRateLimitError(Exception):
+    pass
+
+
+class _FakeTimeout(Exception):
+    pass
+
+
+_fake_exceptions.AuthenticationError = _FakeAuthenticationError
+_fake_exceptions.BadRequestError = _FakeBadRequestError
+_fake_exceptions.NotFoundError = _FakeNotFoundError
+_fake_exceptions.RateLimitError = _FakeRateLimitError
+_fake_exceptions.Timeout = _FakeTimeout
+
+_fake_litellm.exceptions = _fake_exceptions
 
 _fake_message = mock.MagicMock()
 _fake_message.content = "Test summary"
@@ -18,14 +50,22 @@ _fake_response = mock.MagicMock()
 _fake_response.choices = [_fake_choice]
 
 _fake_litellm.completion = mock.MagicMock(return_value=_fake_response)
+
 sys.modules["litellm"] = _fake_litellm
+sys.modules["litellm.exceptions"] = _fake_exceptions
 
 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 @pytest.fixture(autouse=True)
 def reset_mocks():
     _fake_litellm.completion.reset_mock()
+    _fake_litellm.completion.side_effect = None
     _fake_litellm.completion.return_value = _fake_response
     _fake_message.content = "Test summary"
+    _fake_choice.message = _fake_message
+    _fake_response.choices = [_fake_choice]
     yield
 
 
@@ -45,49 +85,52 @@ miniflux:
 """
     )
     monkeypatch.chdir(tmp_path)
-    # Clear cached modules so Config re-reads config.yml from new cwd
     for mod_name in list(sys.modules):
         if mod_name.startswith("core.") or mod_name.startswith("common."):
             del sys.modules[mod_name]
     yield
 
 
-def test_litellm_basic_call():
+def _get_ai_result():
     from core.get_ai_result import get_ai_result
+    return get_ai_result
 
-    result = get_ai_result("Summarize this", "<p>Hello world</p>")
+
+# ---------------------------------------------------------------------------
+# Unit tests: basic functionality
+# ---------------------------------------------------------------------------
+def test_basic_call():
+    result = _get_ai_result()("Summarize this", "<p>Hello world</p>")
     assert result == "Test summary"
     _fake_litellm.completion.assert_called_once()
 
 
-def test_litellm_drop_params():
-    from core.get_ai_result import get_ai_result
-
-    get_ai_result("Summarize", "<p>Test</p>")
+def test_drop_params_always_true():
+    _get_ai_result()("Summarize", "<p>Test</p>")
     call_kwargs = _fake_litellm.completion.call_args[1]
     assert call_kwargs["drop_params"] is True
 
 
-def test_litellm_model_forwarded():
-    from core.get_ai_result import get_ai_result
-
-    get_ai_result("Summarize", "<p>Test</p>")
+def test_model_forwarded():
+    _get_ai_result()("Summarize", "<p>Test</p>")
     call_kwargs = _fake_litellm.completion.call_args[1]
     assert call_kwargs["model"] == "anthropic/claude-sonnet-4-6"
 
 
-def test_litellm_api_key_forwarded():
-    from core.get_ai_result import get_ai_result
-
-    get_ai_result("Summarize", "<p>Test</p>")
+def test_api_key_forwarded():
+    _get_ai_result()("Summarize", "<p>Test</p>")
     call_kwargs = _fake_litellm.completion.call_args[1]
     assert call_kwargs["api_key"] == "sk-test-123"
 
 
-def test_litellm_content_placeholder():
-    from core.get_ai_result import get_ai_result
+def test_timeout_forwarded():
+    _get_ai_result()("Summarize", "<p>Test</p>")
+    call_kwargs = _fake_litellm.completion.call_args[1]
+    assert call_kwargs["timeout"] == 30
 
-    get_ai_result("Process ${content} now", "<p>Hello</p>")
+
+def test_content_placeholder_uses_system_assistant():
+    _get_ai_result()("Process ${content} now", "<p>Hello</p>")
     call_kwargs = _fake_litellm.completion.call_args[1]
     messages = call_kwargs["messages"]
     assert messages[0]["role"] == "system"
@@ -95,19 +138,153 @@ def test_litellm_content_placeholder():
     assert "Hello" in messages[1]["content"]
 
 
-def test_litellm_system_prompt():
-    from core.get_ai_result import get_ai_result
-
-    get_ai_result("Custom system prompt", "<p>Content</p>")
+def test_no_placeholder_uses_prompt_as_system():
+    _get_ai_result()("Custom system prompt", "<p>Content</p>")
     call_kwargs = _fake_litellm.completion.call_args[1]
     messages = call_kwargs["messages"]
     assert messages[0]["role"] == "system"
     assert messages[0]["content"] == "Custom system prompt"
 
 
-def test_litellm_timeout_forwarded():
-    from core.get_ai_result import get_ai_result
+def test_provider_prefixed_model_string():
+    _get_ai_result()("Hi", "<p>Test</p>")
+    call_kwargs = _fake_litellm.completion.call_args[1]
+    assert "/" in call_kwargs["model"]
 
+
+# ---------------------------------------------------------------------------
+# Unit tests: API key omitted when not set
+# ---------------------------------------------------------------------------
+def test_api_key_omitted_when_none(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(
+        """
+llm:
+  provider: litellm
+  model: openai/gpt-4o-mini
+  timeout: 30
+miniflux:
+  base_url: http://localhost
+  api_key: test
+"""
+    )
+    monkeypatch.chdir(tmp_path)
+    for mod_name in list(sys.modules):
+        if mod_name.startswith("core.") or mod_name.startswith("common."):
+            del sys.modules[mod_name]
+
+    from core.get_ai_result import get_ai_result
     get_ai_result("Summarize", "<p>Test</p>")
     call_kwargs = _fake_litellm.completion.call_args[1]
+    assert "api_key" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: exception handling (litellm-specific exceptions)
+# ---------------------------------------------------------------------------
+def test_auth_error_raises():
+    _fake_litellm.completion.side_effect = _FakeAuthenticationError("Invalid API key")
+    with pytest.raises(_FakeAuthenticationError, match="Invalid API key"):
+        _get_ai_result()("Summarize", "<p>Test</p>")
+
+
+def test_not_found_error_raises():
+    _fake_litellm.completion.side_effect = _FakeNotFoundError("Model not found")
+    with pytest.raises(_FakeNotFoundError, match="Model not found"):
+        _get_ai_result()("Summarize", "<p>Test</p>")
+
+
+def test_rate_limit_error_raises():
+    _fake_litellm.completion.side_effect = _FakeRateLimitError("429 Too Many Requests")
+    with pytest.raises(_FakeRateLimitError, match="429"):
+        _get_ai_result()("Summarize", "<p>Test</p>")
+
+
+def test_timeout_error_raises():
+    _fake_litellm.completion.side_effect = _FakeTimeout("Request timed out")
+    with pytest.raises(_FakeTimeout, match="timed out"):
+        _get_ai_result()("Summarize", "<p>Test</p>")
+
+
+def test_bad_request_error_raises():
+    _fake_litellm.completion.side_effect = _FakeBadRequestError("context_length_exceeded")
+    with pytest.raises(_FakeBadRequestError, match="context_length_exceeded"):
+        _get_ai_result()("Summarize", "<p>Test</p>")
+
+
+def test_generic_exception_still_raises():
+    _fake_litellm.completion.side_effect = RuntimeError("unexpected")
+    with pytest.raises(RuntimeError, match="unexpected"):
+        _get_ai_result()("Summarize", "<p>Test</p>")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: empty/null/malformed response
+# ---------------------------------------------------------------------------
+def test_empty_response_content_returns_empty_string():
+    _fake_message.content = None
+    result = _get_ai_result()("Summarize", "<p>Test</p>")
+    assert result == ""
+
+
+def test_empty_string_response():
+    _fake_message.content = ""
+    result = _get_ai_result()("Summarize", "<p>Test</p>")
+    assert result == ""
+
+
+def test_no_choices_raises():
+    _fake_response.choices = []
+    with pytest.raises((IndexError, AttributeError)):
+        _get_ai_result()("Summarize", "<p>Test</p>")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: max_length truncation
+# ---------------------------------------------------------------------------
+def test_max_length_truncation(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(
+        """
+llm:
+  provider: litellm
+  model: openai/gpt-4o-mini
+  api_key: sk-test
+  timeout: 30
+  max_length: 10
+miniflux:
+  base_url: http://localhost
+  api_key: test
+"""
+    )
+    monkeypatch.chdir(tmp_path)
+    for mod_name in list(sys.modules):
+        if mod_name.startswith("core.") or mod_name.startswith("common."):
+            del sys.modules[mod_name]
+
+    from core.get_ai_result import get_ai_result
+    get_ai_result("Summarize ${content}", "<p>" + "A" * 100 + "</p>")
+    call_kwargs = _fake_litellm.completion.call_args[1]
+    user_content = call_kwargs["messages"][1]["content"]
+    assert len(user_content) < 100
+
+
+# ---------------------------------------------------------------------------
+# Integration test: full mocked request-response cycle
+# ---------------------------------------------------------------------------
+def test_full_request_response_cycle():
+    get_ai_result = _get_ai_result()
+    result = get_ai_result(
+        "You are a news summarizer. Summarize: ${content}",
+        "<html><body><h1>Breaking News</h1><p>AI advances continue.</p></body></html>",
+    )
+    assert result == "Test summary"
+    call_kwargs = _fake_litellm.completion.call_args[1]
+    assert call_kwargs["model"] == "anthropic/claude-sonnet-4-6"
+    assert call_kwargs["drop_params"] is True
+    assert call_kwargs["api_key"] == "sk-test-123"
     assert call_kwargs["timeout"] == 30
+    assert len(call_kwargs["messages"]) == 2
+    assert call_kwargs["messages"][0]["role"] == "system"
+    assert call_kwargs["messages"][1]["role"] == "user"
+    assert "AI advances" in call_kwargs["messages"][1]["content"]


### PR DESCRIPTION
## Summary
- Adds LiteLLM as a third provider option alongside OpenAI and Gemini, giving users access to 100+ LLM providers (Anthropic, Groq, Together AI, AWS Bedrock, Azure, Mistral, etc.) through a single config change
- Set `provider: litellm` in config.yml and use provider-prefixed model strings

## Motivation
Users currently choose between `openai` (+ OpenAI-compatible endpoints) and `gemini`. Adding Anthropic, Groq, Bedrock, or any other provider would require a new code branch each time. LiteLLM provides a single `litellm.completion()` call that routes to 100+ providers using provider-prefixed model strings, so users can switch providers with just a config change.

## Changes
- `core/get_ai_result.py` - added `litellm` provider branch with litellm-specific exception handling (`AuthenticationError`, `NotFoundError`, `RateLimitError`, `Timeout`, `BadRequestError`); extracted `_build_messages()` helper shared between OpenAI and LiteLLM paths
- `requirements.txt` - added `litellm>=1.80.0,<1.87`
- `config.sample.English.yml` - added LiteLLM config example
- `tests/test_litellm_provider.py` - 20 unit tests

## Key design decisions
- **`drop_params=True` always set** - LiteLLM silently drops per-provider-unsupported kwargs (e.g. `frequency_penalty` on Anthropic). Prevents cross-provider errors
- **litellm-specific exceptions** - catches `AuthenticationError`, `NotFoundError`, `RateLimitError`, `Timeout`, `BadRequestError` with descriptive error messages (not generic `Exception`)
- **Null response handling** - returns empty string if provider returns `None` content
- **API key optional** - when not set, LiteLLM reads from provider env vars (`ANTHROPIC_API_KEY`, etc.)

## Tests

**1. Unit tests (20 passed, full edge case coverage):**
```
test_basic_call PASSED
test_drop_params_always_true PASSED
test_model_forwarded PASSED
test_api_key_forwarded PASSED
test_timeout_forwarded PASSED
test_content_placeholder_uses_system_assistant PASSED
test_no_placeholder_uses_prompt_as_system PASSED
test_provider_prefixed_model_string PASSED
test_api_key_omitted_when_none PASSED
test_auth_error_raises PASSED
test_not_found_error_raises PASSED
test_rate_limit_error_raises PASSED
test_timeout_error_raises PASSED
test_bad_request_error_raises PASSED
test_generic_exception_still_raises PASSED
test_empty_response_content_returns_empty_string PASSED
test_empty_string_response PASSED
test_no_choices_raises PASSED
test_max_length_truncation PASSED
test_full_request_response_cycle PASSED
======================== 20 passed in 0.65s
```

**Edge cases covered:**
- Auth error (invalid key) - raises `AuthenticationError`
- Model not found - raises `NotFoundError`
- Rate limit (429) - raises `RateLimitError`
- Timeout - raises `Timeout`
- Bad request (context overflow) - raises `BadRequestError`
- Generic exception - still raises
- Empty/null response content - returns `""`
- No choices in response - raises `IndexError`
- Max length truncation - input truncated before sending
- Full request-response cycle - verifies all kwargs

**2. Regression (existing tests unaffected):**
```
tests/test_config.py - 3 passed
tests/test_feeds_status.py - 4 passed, 1 skipped
tests/test_litellm_provider.py - 20 passed
======================== 28 passed, 1 skipped
```

**3. Live E2E against Azure AI Foundry (Anthropic Claude Sonnet 4.6):**
```
Model: claude-sonnet-4-6
Content: OK
Usage: Usage(completion_tokens=4, prompt_tokens=13, total_tokens=17)
LIVE E2E PASSED
```

## Risk / Compatibility
- Additive only, existing OpenAI and Gemini paths untouched
- The only refactor is extracting `_build_messages()` which both OpenAI and LiteLLM now share (same logic, tested)

## Example usage

```yaml
# config.yml
llm:
  provider: litellm
  model: anthropic/claude-sonnet-4-6
  # api_key: sk-ant-...  # optional, reads from ANTHROPIC_API_KEY env var
  timeout: 60
```

```python
# Programmatic usage
from core.get_ai_result import get_ai_result

result = get_ai_result(
    "Summarize the following: ${content}",
    "<p>Breaking news: AI advances continue rapidly...</p>"
)
print(result)
```
