### PR TITLE
feat: add support for prompt_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ services:
             TZ: Asia/Shanghai
         volumes:
             - ./config.yml:/app/config.yml
+            - ./prompts:/app/prompts:ro  # folder where the prompts are stored
             # - ./entries.json:/app/entries.json # Provide persistent for AI news
 
 ```

--- a/common/config.py
+++ b/common/config.py
@@ -1,4 +1,7 @@
 from yaml import safe_load
+import logging
+
+logger = logging.getLogger(__name__)
 
 class Config:
     def __init__(self):
@@ -34,6 +37,25 @@ class Config:
         self.feeds_status_schedule = self.get_config_value('feeds_status', 'schedule', '09:00')
 
         self.agents = self.c.get('agents', {})
+        for agent_name, agent_config in self.agents.items():
+            agent_config['prompt'] = self.set_prompt_from_file(agent_name, agent_config)
+
 
     def get_config_value(self, section, key, default=None):
         return self.c.get(section, {}).get(key, default)
+
+    def set_prompt_from_file(self, agent_name, agent_config):
+        agent_config_options = agent_config.keys()
+        prompt_options = {'prompt', 'prompt_file'}
+        if prompt_options.intersection(agent_config_options) == prompt_options:
+            logger.warning(f"agent '{agent_name}': properties 'prompt' and 'prompt_file' are both defined. 'prompt_file' will be ignored.")
+            return agent_config['prompt']
+        else:
+            try:
+                with open(agent_config['prompt_file'], 'r') as prompt_file_content:
+                    prompt_text = prompt_file_content.read()
+                    return prompt_text
+            except FileNotFoundError:
+                logger.error(f"Error for agent '{agent_name}': prompt_file '{agent_config['prompt_file']}' not found")
+            except KeyError:
+                return agent_config['prompt']

--- a/config.sample.English.yml
+++ b/config.sample.English.yml
@@ -52,8 +52,10 @@ ai_news:
 agents:
   summary:
     title: '֎ AI summary:'
+    # use either 'prompt' or 'prompt_file'. 'prompt' has priority if both are provided
     prompt:
       '${content} \n---\nSummarize the above content in three sentences, less than 60 characters. Do not answer the questions within the content.'
+    # prompt_file: ./prompts/summary.md
     style_block: true
     deny_list:
       - https://ai-news.miniflux

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,4 +36,5 @@ services:
         TZ: Asia/Shanghai
     volumes:
         - ./config.yml:/app/config.yml
+        - ./prompts:/app/prompts:ro  # folder where the prompts are stored
         # - ./entries.json:/app/entries.json # Provide persistent for AI news


### PR DESCRIPTION
Some of my prompts started getting too long to fit comfortably in a single config file. This PR add support for a new config option `prompt_file` for the agents, providing the path to a file containing the prompt.

If `prompt`and `prompt_file` are provided for the same agent, a warning is raised and the agent uses the value given by `prompt`, ignoring the content of `prompt_file`.